### PR TITLE
Not working with mongoose@5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ npm install mongoose-seeder
 ## How to use
 
 ```JavaScript
-var seeder = require('mongoose-seeder'),
+var mongoose = require("mongoose");
+// ...
+var seeder = require('mongoose-seeder')(mongoose),
     data = require('./data.json');
 
 seeder.seed(data).then(function(dbData) {

--- a/index.js
+++ b/index.js
@@ -10,13 +10,12 @@
 
 // module dependencies
 var vm = require('vm'),
-    mongoose = require('mongoose'),
     async = require('async'),
     _ = require('lodash'),
     Q = require('q'),
     objectAssign = require('object-assign');
 
-module.exports = (function() {
+module.exports = function(mongoose) {
 
     // The default options
     var DEFAULT_OPTIONS = {
@@ -290,4 +289,4 @@ module.exports = (function() {
             return def.promise;
         }
     };
-})();
+};


### PR DESCRIPTION
Hi. I want to use your mongoose-seeder package. But it doesn't work with the current version of mongoose.
As far as  I can see three years ago you fixed a similar bug when there was a transition to version 4.x.
I suggest you to change the package in such a way that it does not depend on the mongoose from the inside, and users could transfer their working instances when connecting the package.
I think in this case, such problems will not be for a long time.

```js
const mongoose = require("mongoose"),
        seeder = require("mongoose-seeder")(mongoose);
```