### PR TITLE
Connection fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 coverage/
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 When testing an application, you always want to start with the same database. It is a lot of work to manually create
 dummy data and link them together. When you want extra data to test with, you'll have to create your mongoose objects
-manually in the ```before``` method of the entire testsuite.
+manually in the `before` method of the entire testsuite.
 
 This library offers a nice, clean and elegant solution that will create the dummy data objects from a JSON file.
 
@@ -27,14 +27,19 @@ npm install mongoose-seeder
 var seeder = require('mongoose-seeder'),
     data = require('./data.json');
 
-seeder.seed(data).then(function(dbData) {
+mongoose.connect(dbUri).then(() => {
+  require('./modelOne');
+  require('./modelTwo');
+  seeder.seed(mongoose.connection, data).then(function(dbData) {
     // The database objects are stored in dbData
-}).catch(function(err) {
-    // handle error
-});
+  }).catch(function(err) {
+      // handle error
+  }).finally(() => mongoose.connection.close());
+})
 ```
 
-The ```seed``` function has two options.
+The `seed` function has three arguments.
+* **connection**: The Mongoose connection to which the models have been scoped.
 * **data**: The JSON objects that will be used to create the mongo documents.
 * **options**: [optional] Extra options that alter the behaviour. The default behaviour is drop the entire database before seeding it again.
 
@@ -44,7 +49,7 @@ Although, promises are the preferred way of using the library. It's also possibl
 in the seed function.
 
 ```JavaScript
-seeder.seed(data, function(err, dbData) {
+seeder.seed(connection, data, function(err, dbData) {
     // ...
 })
 ```
@@ -61,13 +66,13 @@ nothing and just add the data to the collections. The default behaviour is to dr
 
 #### Drop database
 
-By setting this property to ```true```, it will drop the entire database before creating the documents again. This
-is the default behaviour. If you set this property to ```false```, it will do nothing and just tries to append the
+By setting this property to `true`, it will drop the entire database before creating the documents again. This
+is the default behaviour. If you set this property to `false`, it will do nothing and just tries to append the
 documents to the collection.
 
 ```JavaScript
 // Drop the entire database (default behaviour)
-seeder.seed(data, {dropDatabase: true}).then(function(dbData) {
+seeder.seed(connection, data, {dropDatabase: true}).then(function(dbData) {
     // ...
 }).catch(function(err) {
     // handle error
@@ -76,12 +81,12 @@ seeder.seed(data, {dropDatabase: true}).then(function(dbData) {
 
 #### Drop collections
 
-By setting this option to ```true```, it will only drop the collections that are being seeded. If you have two collections
+By setting this option to `true`, it will only drop the collections that are being seeded. If you have two collections
 for example, but only one collection is filled by the seeder, only that collection will be dropped.
 
 ```JavaScript
 // Drop the entire database (default behaviour)
-seeder.seed(data, {dropCollections: true}).then(function(dbData) {
+seeder.seed(connection, data, {dropCollections: true}).then(function(dbData) {
     // ...
 }).catch(function(err) {
     // handle error
@@ -92,7 +97,7 @@ seeder.seed(data, {dropCollections: true}).then(function(dbData) {
 
 #### Simple data
 
-How does a json file looks like? Take a look at this simple example.
+What does a json file looks like? Take a look at this simple example.
 
 ```json
 {
@@ -107,7 +112,7 @@ How does a json file looks like? Take a look at this simple example.
 }
 ```
 
-It will try to find the mongoose model ```User``` and calls the ```create``` method for the foo object.
+It will try to find the mongoose model `User` and calls the `create` method for the foo object.
 
 The reason that this isn't an array of items, is because in the callback method, the second parameter returns the database object. This
 will look like this.
@@ -130,7 +135,7 @@ So the foo user can be accessed as following.
 
 ```JavaScript
 // Drop the entire database (default behaviour)
-seeder.seed(data, {dropCollections: true}, function(err, dbData) {
+seeder.seed(connection, data, {dropCollections: true}, function(err, dbData) {
     var foo = dbData.users.foo;
 });
 ```
@@ -170,8 +175,8 @@ document. It is possible to do that with this library.
 }
 ```
 
-A team holds a list of users with the ```_id``` and the ```email``` of that user. Notice that writing ```->users.foo``` is identical
-to writing ```->users.foo._id```.
+A team holds a list of users with the `_id` and the `email` of that user. Notice that writing `->users.foo` is identical
+to writing `->users.foo._id`.
 
 Another thing that should be taken into account is that it's not possible to do a forward reference. This means that in this case,
 a user cannot reference a team. The reason for this is that at the time the user is being created, the team does not yet exist. This
@@ -195,7 +200,7 @@ Sometimes you will need something as an expression, for instance to set the birt
 }
 ```
 
-Every statement that is preceded by an ```=```-sign will be evaluated by the native ```eval()``` method of JavaScript.
+Every statement that is preceded by an `=`-sign will be evaluated by the native `eval()` method of JavaScript.
 
 We can also bring it a step further and reference to the object itself. For instance, if we want to store the full name of
 the user aswell, instead of adding it manually, you can do something like this.
@@ -215,11 +220,11 @@ the user aswell, instead of adding it manually, you can do something like this.
 }
 ```
 
-The result of the ```fullName``` expression will be ```Foo Bar```. So every evaluation is evaluated in it's own context.
+The result of the `fullName` expression will be `Foo Bar`. So every evaluation is evaluated in it's own context.
 
 #### Dependencies
 
-What if we don't want to make use of the plain old ```Date``` object, but instead use something like ```moment```. This is possible by
+What if we don't want to make use of the plain old `Date` object, but instead use something like `moment`. This is possible by
 adding a list of dependencies.
 
 ```json
@@ -240,7 +245,7 @@ adding a list of dependencies.
 ```
 
 If you are using a dependency in your json file, be sure to install it as dependency in your project. If not, it will stop the execution
-and return a ```MODULE_NOT_FOUND``` error in the callback function.
+and return a `MODULE_NOT_FOUND` error in the callback function.
 
 ## Contributors
 

--- a/index.js
+++ b/index.js
@@ -31,10 +31,11 @@ module.exports = (function() {
         /**
          * The internal method for seeding the database.
          *
-         * @param  {Object}   data The data that should be seeded.
-         * @param  {Function} done The method that should be called when the seeding is done
+         * @param  {Object}   connection  The Mongoose connection to which the models are scoped
+         * @param  {Object}   data        The data that should be seeded.
+         * @param  {Function} done        The method that should be called when the seeding is done
          */
-        _seed: function(data, done) {
+        _seed: function(connection, data, done) {
             try {
                 // Retrieve all the dependencies
                 _.forEach(data._dependencies || {}, function(value, key) {
@@ -72,13 +73,13 @@ module.exports = (function() {
                     delete value._model;
 
                     // retrieve the model depending on the name provided
-                    var Model = mongoose.model(modelName);
+                    var Model = connection.model(modelName);
 
                     async.series([
                         function(callback) {
                             if(_this.options.dropCollections === true) {
                                 // Drop the collection
-                                mongoose.connection.db.dropCollection(Model.collection.name, function(err) {
+                                connection.db.dropCollection(Model.collection.name, function(err) {
                                     callback();
                                 });
                             }
@@ -218,11 +219,12 @@ module.exports = (function() {
         /**
          * Start seeding the database.
          *
-         * @param  {Object}   data     The data object that should be inserted in the database.
-         * @param  {Object}   options  The options object to provide extras.
-         * @param  {Function} callback The method that should be called when the seeding is done.
+         * @param  {Object}   connection  The Mongoose connection to which the models are scoped
+         * @param  {Object}   data        The data object that should be inserted in the database.
+         * @param  {Object}   options     The options object to provide extras.
+         * @param  {Function} callback    The method that should be called when the seeding is done.
          */
-        seed: function(data, options, callback) {
+        seed: function(connection, data, options, callback) {
             if(_.isFunction(options)) {
                 // Set the correct callback function
                 callback = options;
@@ -252,19 +254,19 @@ module.exports = (function() {
 
             if(_this.options.dropDatabase === true) {
                 // Make sure to drop the database first
-                mongoose.connection.db.dropDatabase(function(err) {
+                connection.db.dropDatabase(function(err) {
                     if(err) {
                         // Stop seeding if an error occurred
                         return done(err);
                     }
 
                     // Start seeding when the database is dropped
-                    _this._seed(_.cloneDeep(data), done);
+                    _this._seed(connection, _.cloneDeep(data), done);
                 });
             }
             else {
                 // Do not drop the entire database, start seeding
-                _this._seed(_.cloneDeep(data), done);
+                _this._seed(connection, _.cloneDeep(data), done);
             }
 
             /**

--- a/test/test.js
+++ b/test/test.js
@@ -69,7 +69,7 @@ describe('Mongoose Seeder', function() {
 
             it('Should return an error if the connection with the database failed', function(done) {
                 mongoose.disconnect(function() {
-                    seeder.seed(simpleData, function(err) {
+                    seeder.seed(mongoose.connection, simpleData, function(err) {
                         should.exist(err);
 
                         connect(done);
@@ -80,7 +80,7 @@ describe('Mongoose Seeder', function() {
             it('Should call the create method of the User model', sinon.test(function(done) {
                 this.spy(mongoose.model('User'), 'create');
 
-                seeder.seed(simpleData, function(err) {
+                seeder.seed(mongoose.connection, simpleData, function(err) {
                     if(err) return done(err);
 
                     User.create.should.have.been.calledOnce;
@@ -92,7 +92,7 @@ describe('Mongoose Seeder', function() {
             it('Should call the create method of the User model with the foo object', sinon.test(function(done) {
                 this.spy(mongoose.model('User'), 'create');
 
-                seeder.seed(simpleData, function(err) {
+                seeder.seed(mongoose.connection, simpleData, function(err) {
                     if(err) return done(err);
 
                     User.create.should.have.been.calledWith(simpleData.users.foo);
@@ -104,7 +104,7 @@ describe('Mongoose Seeder', function() {
             it('Should create exactly one object in the database', sinon.test(function(done) {
                 this.spy(mongoose.model('User'), 'create');
 
-                seeder.seed(simpleData, function(err) {
+                seeder.seed(mongoose.connection, simpleData, function(err) {
                     if(err) return done(err);
 
                     User.count(function(err, count) {
@@ -120,7 +120,7 @@ describe('Mongoose Seeder', function() {
             it('Should create a second object if the dropDatabase property is set to false', sinon.test(function(done) {
                 this.spy(mongoose.model('User'), 'create');
 
-                seeder.seed(simpleData, {dropDatabase: false}, function(err) {
+                seeder.seed(mongoose.connection, simpleData, {dropDatabase: false}, function(err) {
                     if(err) return done(err);
 
                     User.count(function(err, count) {
@@ -136,7 +136,7 @@ describe('Mongoose Seeder', function() {
             it('Should return an error if the model does not exist', function(done) {
                 simpleData.users._model = 'Users';
 
-                seeder.seed(simpleData, function(err) {
+                seeder.seed(mongoose.connection, simpleData, function(err) {
                     should.exist(err);
 
                     done();
@@ -146,7 +146,7 @@ describe('Mongoose Seeder', function() {
             it('Should return an error if the validation failed when creating an object', function(done) {
                 delete simpleData.users.foo.email;
 
-                seeder.seed(simpleData, function(err) {
+                seeder.seed(mongoose.connection, simpleData, function(err) {
                     should.exist(err);
 
                     done();
@@ -156,7 +156,7 @@ describe('Mongoose Seeder', function() {
             it('Should return an error if the _model property went missing', function(done) {
                 delete simpleData.users._model;
 
-                seeder.seed(simpleData, function(err) {
+                seeder.seed(mongoose.connection, simpleData, function(err) {
                     should.exist(err);
 
                     done();
@@ -169,7 +169,7 @@ describe('Mongoose Seeder', function() {
             it('Should drop the database if no options are provided', sinon.test(function(done) {
                 this.spy(mongoose.connection.db, 'dropDatabase');
 
-                seeder.seed(simpleData, function(err, dbData) {
+                seeder.seed(mongoose.connection, simpleData, function(err, dbData) {
                     if(err) return done(err);
 
                     mongoose.connection.db.dropDatabase.should.have.been.calledOnce;
@@ -181,7 +181,7 @@ describe('Mongoose Seeder', function() {
             it('Should not drop the database if the dropDatabase option is set to false', sinon.test(function(done) {
                 this.spy(mongoose.connection.db, 'dropDatabase');
 
-                seeder.seed(simpleData, {dropDatabase: false}, function(err) {
+                seeder.seed(mongoose.connection, simpleData, {dropDatabase: false}, function(err) {
                     if(err) return done(err);
 
                     mongoose.connection.db.dropDatabase.should.not.have.been.called;
@@ -193,7 +193,7 @@ describe('Mongoose Seeder', function() {
             it('Should drop the users collection if the dropCollections option is set to true', sinon.test(function(done) {
                 this.spy(mongoose.connection.db, 'dropCollection');
 
-                seeder.seed(simpleData, {dropCollections: true}, function(err) {
+                seeder.seed(mongoose.connection, simpleData, {dropCollections: true}, function(err) {
                     if(err) return done(err);
 
                     mongoose.connection.db.dropCollection.should.have.been.calledWith('users');
@@ -205,7 +205,7 @@ describe('Mongoose Seeder', function() {
             it('Should not drop the database if the dropCollections option is set to true', sinon.test(function(done) {
                 this.spy(mongoose.connection.db, 'dropDatabase');
 
-                seeder.seed(simpleData, {dropCollections: true}, function(err) {
+                seeder.seed(mongoose.connection, simpleData, {dropCollections: true}, function(err) {
                     if(err) return done(err);
 
                     mongoose.connection.db.dropDatabase.should.not.have.been.called;
@@ -218,7 +218,7 @@ describe('Mongoose Seeder', function() {
         describe('References', function() {
 
             it('Should create a team with one user', function(done) {
-                seeder.seed(refData, function(err, dbData) {
+                seeder.seed(mongoose.connection, refData, function(err, dbData) {
                     if(err) return done(err);
 
                     dbData.teams.teamA.users.should.have.length(1);
@@ -228,7 +228,7 @@ describe('Mongoose Seeder', function() {
             });
 
             it('Should set the correct ID of the user in the team', function(done) {
-                seeder.seed(refData, function(err, dbData) {
+                seeder.seed(mongoose.connection, refData, function(err, dbData) {
                     if(err) return done(err);
 
                     var user = dbData.teams.teamA.users[0];
@@ -240,7 +240,7 @@ describe('Mongoose Seeder', function() {
             });
 
             it('Should set the correct email of the user in the team', function(done) {
-                seeder.seed(refData, function(err, dbData) {
+                seeder.seed(mongoose.connection, refData, function(err, dbData) {
                     if(err) return done(err);
 
                     var user = dbData.teams.teamA.users[0];
@@ -254,7 +254,7 @@ describe('Mongoose Seeder', function() {
             it('Should return an error if the reference references to an object but the object does not have an _id property', function(done) {
                 refData.teams.teamA.users[0].user = '->users';
 
-                seeder.seed(refData, function(err, dbData) {
+                seeder.seed(mongoose.connection, refData, function(err, dbData) {
                     should.exist(err);
 
                     done();
@@ -264,7 +264,7 @@ describe('Mongoose Seeder', function() {
             it('Should return an error if the property in the reference was not found', function(done) {
                 refData.teams.teamA.users[0].email = '->users.fooo.email';
 
-                seeder.seed(refData, function(err, dbData) {
+                seeder.seed(mongoose.connection, refData, function(err, dbData) {
                     should.exist(err);
 
                     done();
@@ -274,7 +274,7 @@ describe('Mongoose Seeder', function() {
             it('Should return an error if the object of the reference was not found', function(done) {
                 refData.teams.teamA.users[0].email = '->user.foo.email';
 
-                seeder.seed(refData, function(err, dbData) {
+                seeder.seed(mongoose.connection, refData, function(err, dbData) {
                     should.exist(err);
 
                     done();
@@ -285,7 +285,7 @@ describe('Mongoose Seeder', function() {
         describe('Expressions', function() {
 
             it('Should set the full name to \'Foo Bar\'', function(done) {
-                seeder.seed(evalData, function(err, dbData) {
+                seeder.seed(mongoose.connection, evalData, function(err, dbData) {
                     if(err) return done(err);
 
                     dbData.users.foo.fullName.should.be.equal('Foo Bar');
@@ -295,7 +295,7 @@ describe('Mongoose Seeder', function() {
             });
 
             it('Should set a date as birthday', function(done) {
-                seeder.seed(evalData, function(err, dbData) {
+                seeder.seed(mongoose.connection, evalData, function(err, dbData) {
                     if(err) return done(err);
 
                     dbData.users.foo.birthday.should.be.a('Date');
@@ -305,7 +305,7 @@ describe('Mongoose Seeder', function() {
             });
 
             it('Should set the number of nationalities to 2', function(done) {
-                seeder.seed(evalData, function(err, dbData) {
+                seeder.seed(mongoose.connection, evalData, function(err, dbData) {
                     if(err) return done(err);
 
                     dbData.users.foo.nationalities.should.be.equal(2);
@@ -317,7 +317,7 @@ describe('Mongoose Seeder', function() {
             it('Should not throw an error if the expression could not be processed', function(done) {
                 evalData.users.foo.fullName = '=firstName + \' \' + name';
 
-                seeder.seed(evalData, function(err, dbData) {
+                seeder.seed(mongoose.connection, evalData, function(err, dbData) {
                     should.not.exist(err);
 
                     done();
@@ -327,7 +327,7 @@ describe('Mongoose Seeder', function() {
             it('Should just store the string value of the expression if it could not be processed ', function(done) {
                 evalData.users.foo.fullName = '=firstName + \' \' + name';
 
-                seeder.seed(evalData, function(err, dbData) {
+                seeder.seed(mongoose.connection, evalData, function(err, dbData) {
                     if(err) return done(err);
 
                     dbData.users.foo.fullName.should.be.equal('=firstName + \' \' + name');
@@ -340,7 +340,7 @@ describe('Mongoose Seeder', function() {
         describe('Dependencies', function() {
 
             it('Should not create moment as global variable', function(done) {
-                seeder.seed(dependencyData, function(err, dbData) {
+                seeder.seed(mongoose.connection, dependencyData, function(err, dbData) {
                     if(err) return done(err);
 
                     should.not.exist(global.moment);
@@ -350,7 +350,7 @@ describe('Mongoose Seeder', function() {
             });
 
             it('Should set the birthday of foo to the 25th of July 1988', function(done) {
-                seeder.seed(dependencyData, function(err, dbData) {
+                seeder.seed(mongoose.connection, dependencyData, function(err, dbData) {
                     if(err) return done(err);
 
                     dbData.users.foo.birthday.should.be.eql(moment('1988-07-25').toDate());
@@ -362,7 +362,7 @@ describe('Mongoose Seeder', function() {
             it('Should return an error if the dependency is not found', function(done) {
                 dependencyData._dependencies.unknown = 'unknown';
 
-                seeder.seed(dependencyData, function(err) {
+                seeder.seed(mongoose.connection, dependencyData, function(err) {
                     should.exist(err);
 
                     done();
@@ -372,7 +372,7 @@ describe('Mongoose Seeder', function() {
             it('Should return a \'MODULE_NOT_FOUND\' error if the dependency is not found', function(done) {
                 dependencyData._dependencies.unknown = 'unknown';
 
-                seeder.seed(dependencyData, function(err) {
+                seeder.seed(mongoose.connection, dependencyData, function(err) {
                     err.code.should.be.equal('MODULE_NOT_FOUND');
 
                     done();
@@ -389,7 +389,7 @@ describe('Mongoose Seeder', function() {
 
             it('Should return an error if the connection with the database failed', function(done) {
                 mongoose.disconnect(function() {
-                    seeder.seed(simpleData).catch(function(err) {
+                    seeder.seed(mongoose.connection, simpleData).catch(function(err) {
                         should.exist(err);
 
                         connect(done);
@@ -400,7 +400,7 @@ describe('Mongoose Seeder', function() {
             it('Should call the create method of the User model', sinon.test(function(done) {
                 this.spy(mongoose.model('User'), 'create');
 
-                seeder.seed(simpleData).then(function() {
+                seeder.seed(mongoose.connection, simpleData).then(function() {
                     User.create.should.have.been.calledOnce;
 
                     done();
@@ -410,7 +410,7 @@ describe('Mongoose Seeder', function() {
             it('Should call the create method of the User model with the foo object', sinon.test(function(done) {
                 this.spy(mongoose.model('User'), 'create');
 
-                seeder.seed(simpleData).then(function() {
+                seeder.seed(mongoose.connection, simpleData).then(function() {
                     User.create.should.have.been.calledWith(simpleData.users.foo);
 
                     done();
@@ -420,7 +420,7 @@ describe('Mongoose Seeder', function() {
             it('Should create exactly one object in the database', sinon.test(function(done) {
                 this.spy(mongoose.model('User'), 'create');
 
-                seeder.seed(simpleData).then(function() {
+                seeder.seed(mongoose.connection, simpleData).then(function() {
                     User.count(function(err, count) {
                         if(err) return done(err);
 
@@ -434,7 +434,7 @@ describe('Mongoose Seeder', function() {
             it('Should create a second object if the dropDatabase property is set to false', sinon.test(function(done) {
                 this.spy(mongoose.model('User'), 'create');
 
-                seeder.seed(simpleData, {dropDatabase: false}).then(function() {
+                seeder.seed(mongoose.connection, simpleData, {dropDatabase: false}).then(function() {
                     User.count(function(err, count) {
                         if(err) return done(err);
 
@@ -448,7 +448,7 @@ describe('Mongoose Seeder', function() {
             it('Should return an error if the model does not exist', function(done) {
                 simpleData.users._model = 'Users';
 
-                seeder.seed(simpleData).catch(function(err) {
+                seeder.seed(mongoose.connection, simpleData).catch(function(err) {
                     should.exist(err);
 
                     done();
@@ -458,7 +458,7 @@ describe('Mongoose Seeder', function() {
             it('Should return an error if the validation failed when creating an object', function(done) {
                 delete simpleData.users.foo.email;
 
-                seeder.seed(simpleData).catch(function(err) {
+                seeder.seed(mongoose.connection, simpleData).catch(function(err) {
                     should.exist(err);
 
                     done();
@@ -468,7 +468,7 @@ describe('Mongoose Seeder', function() {
             it('Should return an error if the _model property went missing', function(done) {
                 delete simpleData.users._model;
 
-                seeder.seed(simpleData).catch(function(err) {
+                seeder.seed(mongoose.connection, simpleData).catch(function(err) {
                     should.exist(err);
 
                     done();
@@ -481,7 +481,7 @@ describe('Mongoose Seeder', function() {
             it('Should drop the database if no options are provided', sinon.test(function(done) {
                 this.spy(mongoose.connection.db, 'dropDatabase');
 
-                seeder.seed(simpleData).then(function(dbData) {
+                seeder.seed(mongoose.connection, simpleData).then(function(dbData) {
                     mongoose.connection.db.dropDatabase.should.have.been.calledOnce;
 
                     done();
@@ -491,7 +491,7 @@ describe('Mongoose Seeder', function() {
             it('Should not drop the database if the dropDatabase option is set to false', sinon.test(function(done) {
                 this.spy(mongoose.connection.db, 'dropDatabase');
 
-                seeder.seed(simpleData, {dropDatabase: false}).then(function() {
+                seeder.seed(mongoose.connection, simpleData, {dropDatabase: false}).then(function() {
                     mongoose.connection.db.dropDatabase.should.not.have.been.called;
 
                     done();
@@ -501,7 +501,7 @@ describe('Mongoose Seeder', function() {
             it('Should drop the users collection if the dropCollections option is set to true', sinon.test(function(done) {
                 this.spy(mongoose.connection.db, 'dropCollection');
 
-                seeder.seed(simpleData, {dropCollections: true}).then(function() {
+                seeder.seed(mongoose.connection, simpleData, {dropCollections: true}).then(function() {
                     mongoose.connection.db.dropCollection.should.have.been.calledWith('users');
 
                     done();
@@ -511,7 +511,7 @@ describe('Mongoose Seeder', function() {
             it('Should not drop the database if the dropCollections option is set to true', sinon.test(function(done) {
                 this.spy(mongoose.connection.db, 'dropDatabase');
 
-                seeder.seed(simpleData, {dropCollections: true}).then(function() {
+                seeder.seed(mongoose.connection, simpleData, {dropCollections: true}).then(function() {
                     mongoose.connection.db.dropDatabase.should.not.have.been.called;
 
                     done();
@@ -522,7 +522,7 @@ describe('Mongoose Seeder', function() {
         describe('References', function() {
 
             it('Should create a team with one user', function(done) {
-                seeder.seed(refData).then(function(dbData) {
+                seeder.seed(mongoose.connection, refData).then(function(dbData) {
                     dbData.teams.teamA.users.should.have.length(1);
 
                     done();
@@ -530,7 +530,7 @@ describe('Mongoose Seeder', function() {
             });
 
             it('Should set the correct ID of the user in the team', function(done) {
-                seeder.seed(refData).then(function(dbData) {
+                seeder.seed(mongoose.connection, refData).then(function(dbData) {
                     var user = dbData.teams.teamA.users[0];
 
                     user.user.should.be.eql(dbData.users.foo._id);
@@ -540,7 +540,7 @@ describe('Mongoose Seeder', function() {
             });
 
             it('Should set the correct email of the user in the team', function(done) {
-                seeder.seed(refData).then(function(dbData) {
+                seeder.seed(mongoose.connection, refData).then(function(dbData) {
                     var user = dbData.teams.teamA.users[0];
 
                     user.email.should.be.equal(dbData.users.foo.email);
@@ -552,7 +552,7 @@ describe('Mongoose Seeder', function() {
             it('Should return an error if the reference references to an object but the object does not have an _id property', function(done) {
                 refData.teams.teamA.users[0].user = '->users';
 
-                seeder.seed(refData).catch(function(err) {
+                seeder.seed(mongoose.connection, refData).catch(function(err) {
                     should.exist(err);
 
                     done();
@@ -562,7 +562,7 @@ describe('Mongoose Seeder', function() {
             it('Should return an error if the property in the reference was not found', function(done) {
                 refData.teams.teamA.users[0].email = '->users.fooo.email';
 
-                seeder.seed(refData).catch(function(err) {
+                seeder.seed(mongoose.connection, refData).catch(function(err) {
                     should.exist(err);
 
                     done();
@@ -572,7 +572,7 @@ describe('Mongoose Seeder', function() {
             it('Should return an error if the object of the reference was not found', function(done) {
                 refData.teams.teamA.users[0].email = '->user.foo.email';
 
-                seeder.seed(refData, function(err, dbData) {
+                seeder.seed(mongoose.connection, refData, function(err, dbData) {
                     should.exist(err);
 
                     done();
@@ -583,7 +583,7 @@ describe('Mongoose Seeder', function() {
         describe('Expressions', function() {
 
             it('Should set the full name to \'Foo Bar\'', function(done) {
-                seeder.seed(evalData).then(function(dbData) {
+                seeder.seed(mongoose.connection, evalData).then(function(dbData) {
                     dbData.users.foo.fullName.should.be.equal('Foo Bar');
 
                     done();
@@ -591,7 +591,7 @@ describe('Mongoose Seeder', function() {
             });
 
             it('Should set a date as birthday', function(done) {
-                seeder.seed(evalData).then(function(dbData) {
+                seeder.seed(mongoose.connection, evalData).then(function(dbData) {
                     dbData.users.foo.birthday.should.be.a('Date');
 
                     done();
@@ -599,7 +599,7 @@ describe('Mongoose Seeder', function() {
             });
 
             it('Should set the number of nationalities to 2', function(done) {
-                seeder.seed(evalData).then(function(dbData) {
+                seeder.seed(mongoose.connection, evalData).then(function(dbData) {
                     dbData.users.foo.nationalities.should.be.equal(2);
 
                     done();
@@ -609,7 +609,7 @@ describe('Mongoose Seeder', function() {
             it('Should not throw an error if the expression could not be processed', function(done) {
                 evalData.users.foo.fullName = '=firstName + \' \' + name';
 
-                seeder.seed(evalData).then(function(dbData) {
+                seeder.seed(mongoose.connection, evalData).then(function(dbData) {
                     done();
                 });
             });
@@ -617,7 +617,7 @@ describe('Mongoose Seeder', function() {
             it('Should just store the string value of the expression if it could not be processed ', function(done) {
                 evalData.users.foo.fullName = '=firstName + \' \' + name';
 
-                seeder.seed(evalData).then(function(dbData) {
+                seeder.seed(mongoose.connection, evalData).then(function(dbData) {
                     dbData.users.foo.fullName.should.be.equal('=firstName + \' \' + name');
 
                     done();
@@ -628,7 +628,7 @@ describe('Mongoose Seeder', function() {
         describe('Dependencies', function() {
 
             it('Should not create moment as global variable', function(done) {
-                seeder.seed(dependencyData).then(function(dbData) {
+                seeder.seed(mongoose.connection, dependencyData).then(function(dbData) {
                     should.not.exist(global.moment);
 
                     done();
@@ -636,7 +636,7 @@ describe('Mongoose Seeder', function() {
             });
 
             it('Should set the birthday of foo to the 25th of July 1988', function(done) {
-                seeder.seed(dependencyData).then(function(dbData) {
+                seeder.seed(mongoose.connection, dependencyData).then(function(dbData) {
                     dbData.users.foo.birthday.should.be.eql(moment('1988-07-25').toDate());
 
                     done();
@@ -646,7 +646,7 @@ describe('Mongoose Seeder', function() {
             it('Should return an error if the dependency is not found', function(done) {
                 dependencyData._dependencies.unknown = 'unknown';
 
-                seeder.seed(dependencyData).catch(function(err) {
+                seeder.seed(mongoose.connection, dependencyData).catch(function(err) {
                     should.exist(err);
 
                     done();
@@ -656,7 +656,7 @@ describe('Mongoose Seeder', function() {
             it('Should return a \'MODULE_NOT_FOUND\' error if the dependency is not found', function(done) {
                 dependencyData._dependencies.unknown = 'unknown';
 
-                seeder.seed(dependencyData).catch(function(err) {
+                seeder.seed(mongoose.connection, dependencyData).catch(function(err) {
                     err.code.should.be.equal('MODULE_NOT_FOUND');
 
                     done();


### PR DESCRIPTION
This fixes [a problem](https://stackoverflow.com/q/51197989/2071807) with the way [models are scoped to a connection](http://mongoosejs.com/docs/connections.html#multiple_connections).
This fix applies to Mongoose 5 and also works with Mongoose 4.0.3.

By passing `seeder.seed` (and `_seed`) a connection object to which the models have been scoped, everything works nicely. I've updated the README to show how to use the new API.

```
mongoose.connect(dbUri).then(() => {
  const Venue = require('../models/venue');
  const Post = require('../models/post');
  const User = require('../models/user');
  const Course = require('../models/course');
  seeder.seed(mongoose.connection, seedData, { dropDatabase: false, dropCollections: true }).then(dbData => {
    console.log('seeded');
  }).catch(err => {
    console.log('Error when seeding', err);
  }).finally(() => mongoose.connection.close());
}, err => console.log(err));
```